### PR TITLE
fix issue template selection

### DIFF
--- a/woocommerce-direct-debit-gateway.php
+++ b/woocommerce-direct-debit-gateway.php
@@ -204,10 +204,7 @@ add_action('plugins_loaded', 'init_direct_debits_gateway', 0);
 	// Register metabox
 	add_action( 'add_meta_boxes',  'add_directdebit_metabox' );
 	function add_directdebit_metabox(){
-		global $post;
-		if ( $post->post_type = 'shop_order' ){
 			 add_meta_box( 'direct-debit-metabox', 'IBAN and BIC Information',  'directdebit_information_render', 'shop_order', 'normal', 'default');
-		}
 	}
 	// Pull the $_POST info into the Order type item
 	function directdebit_information_render(){


### PR DESCRIPTION
Disable if shop_order post type, fixes issue with template selection for pages. 
A checking for Woocommerce is made when plugin is loaded so no need to check for the post_type which by default is created with Woocommerce.
